### PR TITLE
Upgrade slevomat/coding-standard to v7.0 and fine-tune ruleset

### DIFF
--- a/Proton/ruleset.xml
+++ b/Proton/ruleset.xml
@@ -128,7 +128,6 @@
             <property name="ignoreComplexTernaryConditions" value="1"/>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
     <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding"/>
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
     <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
@@ -141,7 +140,7 @@
     <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
     <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
     <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
-    <rule ref="SlevomatCodingStandard.Functions.TrailingCommaInCall" />
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall" />
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing"/>
 <!--    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>-->
@@ -185,6 +184,10 @@
             <property name="newlinesCountAfterDeclare" value="2"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat"/>
+
+    <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
 
     <!-- <rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit">
         <properties>

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "php": "^7.1 || ^8.0",
-        "slevomat/coding-standard": "^6.4",
-        "squizlabs/php_codesniffer": "^3.5"
+        "slevomat/coding-standard": "^7.0",
+        "squizlabs/php_codesniffer": "^3.6"
     },
     "license": "MIT"
 }

--- a/tests/correct/ClassOk.php
+++ b/tests/correct/ClassOk.php
@@ -30,10 +30,14 @@ final class ClassOk
 
     public function ping(Request $request)
     {
-        $this->foo(
-            'a',
-            'b',
-        );
+        try {
+            $this->foo(
+                'a',
+                'b',
+            );
+        } catch (\RuntimeException) {
+            // ...
+        }
 
         return $request->query->get('test');
     }
@@ -60,6 +64,21 @@ final class ClassOk
             return $foo;
         }
 
+        if ($a === 'z') {
+            throw new \RuntimeException();
+        }
+
         return false;
+    }
+
+    public static function create(
+        string $name,
+        string|int|float|null $defaultValue = null,
+    ): string|int|float|null|array|object {
+        return match ($name) {
+            'foo' => [1, 2, 3],
+            'bar' => [],
+            default => $defaultValue,
+        };
     }
 }

--- a/tests/expected_csv.txt
+++ b/tests/expected_csv.txt
@@ -15,7 +15,7 @@ Line,Column,Type,Source
 52,20,warning,Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 52,20,error,PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 50,8,error,SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration.MissingDescription
-45,13,error,SlevomatCodingStandard.Functions.TrailingCommaInCall.MissingTrailingComma
+45,13,error,SlevomatCodingStandard.Functions.RequireTrailingCommaInCall.MissingTrailingComma
 44,1,error,Generic.WhiteSpace.DisallowTabIndent.TabsUsed
 43,1,error,Generic.WhiteSpace.DisallowTabIndent.TabsUsed
 41,1,error,Generic.WhiteSpace.DisallowTabIndent.TabsUsed
@@ -34,7 +34,6 @@ Line,Column,Type,Source
 36,24,error,Generic.Formatting.DisallowMultipleStatements.SameLine
 36,1,error,Generic.WhiteSpace.DisallowTabIndent.TabsUsed
 34,31,error,Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
-34,13,error,SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod
 31,24,error,Proton.Spacing.ArrowFunctionSpacing.Found
 28,27,error,PSR12.Classes.AnonClassDeclaration.SpaceAfterKeyword
 25,13,error,SlevomatCodingStandard.Arrays.TrailingArrayComma.MissingTrailingComma
@@ -45,8 +44,8 @@ Line,Column,Type,Source
 16,16,error,PSR12.Traits.UseDeclaration.MultipleImport
 14,5,warning,PSR12.Properties.ConstantVisibility.NotFound
 12,13,error,Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
-12,13,error,SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty
 12,1,error,Generic.WhiteSpace.DisallowTabIndent.TabsUsed
 10,27,error,SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces.IncorrectEmptyLinesAfterOpeningBrace
 10,27,error,PSR2.Classes.ClassDeclaration.OpenBraceNewLine
+10,27,error,PSR12.Classes.OpeningBraceSpace.Found
 1,1,error,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing

--- a/tests/wrong/Class1.php
+++ b/tests/wrong/Class1.php
@@ -49,7 +49,7 @@ abstract final class Test {
     /**
      * @deprecated
      */
-    private static function Foo(string $a, $b, $c) : array
+    private static function Foo(string $a, $b, $c) : array |object
     {
         return [$a, $b];
     }


### PR DESCRIPTION
Upgrade slevomat/coding-standard to v7.0

New rules:
 - SlevomatCodingStandard.TypeHints.UnionTypeHintFormat
 - SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch
 - SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration

Removed:
- SlevomatCodingStandard.Classes.UnusedPrivateElements