### PR TITLE
Add the Namespaces.DisallowGroupUse rule

### DIFF
--- a/Proton/ruleset.xml
+++ b/Proton/ruleset.xml
@@ -142,6 +142,7 @@
     <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall" />
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing"/>
 <!--    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>-->
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>


### PR DESCRIPTION
It's not supported by Slevomat and can cause issue with some of their sniffs (eg: https://github.com/slevomat/coding-standard/issues/1367)