### PR TITLE
Bumb slevomat/coding-standard to v8, add new rules

### DIFF
--- a/Proton/ruleset.xml
+++ b/Proton/ruleset.xml
@@ -128,8 +128,20 @@
             <property name="ignoreComplexTernaryConditions" value="1"/>
         </properties>
     </rule>
+    <!-- Require usage of constructor property promotion -->
+    <rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion"/>
+    <!-- Forbid uses of multiple traits separated by comma -->
+    <rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
     <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding"/>
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
+    <rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration">
+        <properties>
+            <property name="checkPromoted" value="true"/>
+            <property name="enableMultipleSpacesBetweenModifiersCheck" value="true"/>
+        </properties>
+    </rule>
+    <!-- Require no space before : and 1 space before Enum type -->
+    <rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing"/>
     <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
         <properties>
             <property name="linesCountAfterOpeningBrace" value="0"/>
@@ -156,6 +168,13 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+    <!-- Define unions style -->
+    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
+        <properties>
+            <property name="withSpaces" value="no" />
+            <property name="nullPosition" value="last" />
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments"/>
     <rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
     <rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration"/>

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,13 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "slevomat/coding-standard": "^7.0",
-        "squizlabs/php_codesniffer": "^3.6"
+        "slevomat/coding-standard": "^8.0",
+        "squizlabs/php_codesniffer": "^3.7"
     },
-    "license": "MIT"
+    "license": "MIT",
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
 }

--- a/tests/correct/ClassOk.php
+++ b/tests/correct/ClassOk.php
@@ -10,12 +10,17 @@ use function Proton\Support\phpinfo2;
 final class ClassOk
 {
     use MyTrait;
+    use MyTrait2;
+
+    public const FOO_1 = 'A';
+    public const FOO_2 = 'B';
 
     /**
      * Foo.
      * @var array
      */
     protected $foo = [];
+    private string $test = 'foo';
 
     public function __construct(array $config)
     {
@@ -72,9 +77,9 @@ final class ClassOk
     }
 
     public static function create(
-        string $name,
+        ?string $name,
         string|int|float|null $defaultValue = null,
-    ): string|int|float|null|array|object {
+    ): string|int|float|array|object|null {
         return match ($name) {
             'foo' => [1, 2, 3],
             'bar' => [],

--- a/tests/expected_csv.txt
+++ b/tests/expected_csv.txt
@@ -8,9 +8,13 @@ Line,Column,Type,Source
 20,9,error,SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn.UselessIfCondition
 1,1,error,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing
 8,1,error, found 1."
+61,1,error,PSR2.Files.EndFileNewline.NoneFound
 6,18,error,PSR12.Files.FileHeader.SpacingInsideBlock
-56,1,error,PSR2.Files.EndFileNewline.NoneFound
+57,60,error,SlevomatCodingStandard.TypeHints.UnionTypeHintFormat.NullTypeHintNotOnLastPosition
+57,32,error,SlevomatCodingStandard.TypeHints.UnionTypeHintFormat.NullTypeHintNotOnLastPosition
+57,13,warning,Generic.CodeAnalysis.UnusedFunctionParameter.Found
 52,54,error,SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing.WhitespaceBeforeColon
+52,54,error,SlevomatCodingStandard.TypeHints.UnionTypeHintFormat.DisallowedWhitespace
 52,52,error,PSR12.Functions.ReturnTypeDeclaration.SpaceBeforeColon
 52,20,warning,Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 52,20,error,PSR1.Methods.CamelCapsMethodName.NotCamelCaps
@@ -41,6 +45,7 @@ Line,Column,Type,Source
 20,19,error,Generic.PHP.BacktickOperator.Found
 20,14,error,Generic.PHP.BacktickOperator.Found
 16,5,error,PSR12.Traits.UseDeclaration.UseAfterBrace
+16,5,error,SlevomatCodingStandard.Classes.TraitUseDeclaration.MultipleTraitsPerDeclaration
 16,16,error,PSR12.Traits.UseDeclaration.MultipleImport
 14,5,warning,PSR12.Properties.ConstantVisibility.NotFound
 12,13,error,Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps

--- a/tests/wrong/Class1.php
+++ b/tests/wrong/Class1.php
@@ -53,4 +53,9 @@ abstract final class Test {
     {
         return [$a, $b];
     }
+
+    private function testUnion(null|float|int|string $a,): null|int|float
+    {
+        return 1;
+    }
 }


### PR DESCRIPTION
- Bumb slevomat/coding-standard to v8
- Add new rules:
  - SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion
  - SlevomatCodingStandard.Classes.TraitUseDeclaration
  - SlevomatCodingStandard.Classes.PropertyDeclaration
  - SlevomatCodingStandard.Classes.BackedEnumTypeSpacing
  - SlevomatCodingStandard.TypeHints.UnionTypeHintFormat
- Update tests