### PR TITLE
Update deprecated UnionTypeHintFormat

### DIFF
--- a/Proton/ruleset.xml
+++ b/Proton/ruleset.xml
@@ -192,9 +192,9 @@
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
     </rule>
     <!-- Define unions style -->
-    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
+    <rule ref="SlevomatCodingStandard.TypeHints.DNFTypeHintFormat">
         <properties>
-            <property name="withSpaces" value="no" />
+            <property name="withSpacesAroundOperators" value="no" />
             <property name="nullPosition" value="last" />
         </properties>
     </rule>
@@ -238,7 +238,6 @@
             <property name="linesCountAfterDeclare" value="1"/>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat"/>
 
     <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch"/>
 

--- a/tests/expected_csv.txt
+++ b/tests/expected_csv.txt
@@ -59,10 +59,10 @@ Line,Column,Type,Source
 63,62,error,Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine
 6,18,error,PSR12.Files.FileHeader.SpacingInsideBlock
 6,1,error,SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
-58,60,error,SlevomatCodingStandard.TypeHints.UnionTypeHintFormat.NullTypeHintNotOnLastPosition
-58,32,error,SlevomatCodingStandard.TypeHints.UnionTypeHintFormat.NullTypeHintNotOnLastPosition
+58,60,error,SlevomatCodingStandard.TypeHints.DNFTypeHintFormat.NullTypeHintNotOnLastPosition
+58,32,error,SlevomatCodingStandard.TypeHints.DNFTypeHintFormat.NullTypeHintNotOnLastPosition
 53,54,error,SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing.WhitespaceBeforeColon
-53,54,error,SlevomatCodingStandard.TypeHints.UnionTypeHintFormat.DisallowedWhitespace
+53,54,error,SlevomatCodingStandard.TypeHints.DNFTypeHintFormat.DisallowedWhitespaceAroundOperator
 53,52,error,PSR12.Functions.ReturnTypeDeclaration.SpaceBeforeColon
 53,20,error,PSR1.Methods.CamelCapsMethodName.NotCamelCaps
 53,20,error,SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint


### PR DESCRIPTION
```
WARNING: The ProtonLabs PHP CodeSniffer Standard standard uses 1 deprecated sniff
--------------------------------------------------------------------------------------
-  SlevomatCodingStandard.TypeHints.UnionTypeHintFormat
   This sniff has been deprecated since Slevomat Coding Standard 8.16.0 and will be
   removed in Slevomat Coding Standard 9.0.0. Use
   SlevomatCodingStandard.TypeHints.DNFTypeHintFormat instead.

Deprecated sniffs are still run, but will stop working at some point in the future.
```
